### PR TITLE
made cpy use sendfile when possible

### DIFF
--- a/cpy.c
+++ b/cpy.c
@@ -1,5 +1,9 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/sendfile.h>
+#include <sys/stat.h>
+
 #define BUFFSIZE 1024
 int main(int argc, char** argv) {
     if (argc != 3) {
@@ -16,13 +20,33 @@ int main(int argc, char** argv) {
         perror("FATAL ERROR");
         return 2;
     }
-    char buff[BUFFSIZE];
-    while (fread(buff, 1, BUFFSIZE, source) > 0) {
-        if (fwrite(buff, 1, BUFFSIZE, destination) < 0) {
+
+    // Find the size of the source file.
+    struct stat stat;
+    fstat(fileno(source), &stat);
+
+    size_t remaining = stat.st_size;
+    ssize_t sendfile_ret = 0;
+    while ((sendfile_ret = sendfile(fileno(destination), fileno(source), NULL, remaining)) > 0) {
+        // Update the count of remaining bytes, removing those we've just transferred.
+        remaining -= sendfile_ret;
+    }
+
+    if (sendfile_ret < 0) { // error happened
+        if (errno == EINVAL) { // input file isn't mmap'able, fallback to fread/fwrite
+            char buff[BUFFSIZE];
+            while (fread(buff, 1, BUFFSIZE, source) > 0) {
+                if (fwrite(buff, 1, BUFFSIZE, destination) < 0) {
+                    perror("FATAL ERROR");
+                    return 3;
+                }
+            }
+        } else {
             perror("FATAL ERROR");
             return 3;
         }
     }
+
     fclose(source);
     fclose(destination);
     return 0;


### PR DESCRIPTION
This improves the `cpy` tool such that it uses `sendfile` instead of fread/fwrite when possible to avoid a userspace buffer when copying files.  Benchmarks confirm a significant performance improvement when copying a 1G file of random bytes from a tmpfs to /dev/null (as to not benchmark the hard drive instead of the program):
```
Benchmark 1 (15 runs): ./cpy_old /run/user/1000/test1.dat /dev/null
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           348ms ± 10.8ms     343ms …  386ms          1 ( 7%)        0%
  peak_rss           1.59MB ± 1.44KB    1.59MB … 1.59MB          2 (13%)        0%
  cpu_cycles          235M  ± 5.55M      226M  …  243M           0 ( 0%)        0%
  instructions        666M  ±  271K      665M  …  666M           0 ( 0%)        0%
  cache_references    266K  ± 51.9K      205K  …  415K           1 ( 7%)        0%
  cache_misses       8.64K  ±  761      7.60K  … 10.5K           0 ( 0%)        0%
  branch_misses       252K  ±  199K     3.66K  …  456K           0 ( 0%)        0%
Benchmark 2 (218 runs): ./cpy /run/user/1000/test1.dat /dev/null
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          23.0ms ±  128us    22.7ms … 23.3ms          0 ( 0%)        ⚡- 93.4% ±  0.4%
  peak_rss           1.59MB ± 9.00KB    1.46MB … 1.59MB         20 ( 9%)          -  0.0% ±  0.3%
  cpu_cycles          246K  ± 19.4K      226K  …  408K          13 ( 6%)        ⚡- 99.9% ±  0.3%
  instructions        150K  ± 1.13       150K  …  150K           2 ( 1%)        ⚡-100.0% ±  0.0%
  cache_references   12.8K  ±  379      11.8K  … 14.2K           7 ( 3%)        ⚡- 95.2% ±  2.5%
  cache_misses       1.94K  ±  877      1.12K  … 6.80K          11 ( 5%)        ⚡- 77.6% ±  5.3%
  branch_misses      2.52K  ± 38.8      2.45K  … 2.65K           3 ( 1%)        ⚡- 99.0% ± 10.2%
```

The original fread/fwrite implementation is kept as a fallback in case sendfile is unsupported, which may be the case on certain filesystems.

Note: There's a bug in the original code where we'd always write the whole buffer to the destination file, even if it's only partially filled, resulting in garbage data at the end of destination files if they're not an exact multiple of `BUFFSIZE` bytes.  This has been left as an exercise to the maintainer ;)

Note 2: I have just seen that someone's also contributed code that uses `sendfile` for the `mat` tool.  According to `man 2 sendfile`:
> Note that a successful call to sendfile() may write fewer bytes  than requested; the caller should be prepared to retry the call if there were unsent bytes.

This doesn't seem to be correctly implemented there.

Note 3: This isn't optimal yet.  For maximum performance, you'd first want to try `copy_file_range`, which does however not work across filesystem boundaries.  Then, you'd fall back to what we're doing right now.  We'd get better performance here because many filesystems are smart enough not to copy anything at all in that case, and instead just create two references to the same underlying data, also saving disk space.