### PR TITLE
Added a clr command to clear the terminal screen.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BINDIR ?= /usr/local/bin
 MANDIR ?= /usr/local/share/man/man1
 
 # Programs to build
-BINS = mat jgrep move cpy print lf perm spec srt hn chwn brit cnt hd tl tch mkd del lnk cwd env nap dt duct wm whoisdat short sim jfetch jsh
+BINS = mat jgrep move cpy print lf perm spec srt hn chwn brit cnt hd tl tch mkd del lnk cwd env nap dt duct wm whoisdat short sim jfetch jsh clr
 
 # Manual pages
 MANS = man/man1/brit.1 man/man1/chwn.1 man/man1/cnt.1 man/man1/cpy.1 \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Requires: `gcc`, `make`. On Windows, MinGW/MSYS2 or Cygwin is recommended.
 | `move` | `mv`    | `move <src> <dest>`            | Move or rename a file                            |
 | `del`  | `rm`    | `del [-r] <file>...`           | Delete file(s); `-r` removes directories         |
 | `lnk`  | `ln`    | `lnk [-s] <target> <link>`     | Hard link; `-s` creates a symbolic link          |
-| `tch`  | `touch` | `tch <file>...`                | Create file(s) or update modification dt       |
+| `tch`  | `touch` | `tch <file>...`                | Create file(s) or update modification dt         |
 | `brit` | `tee`   | `cmd \| brit <file>`           | Write stdin to both stdout and a file            |
 
 ### Directory Operations
@@ -99,6 +99,7 @@ Requires: `gcc`, `make`. On Windows, MinGW/MSYS2 or Cygwin is recommended.
 | `duct`      | `uname -m` | `duct`                 | Print machine architecture                  |
 | `jfetch`    | `neofetch` | `jfetch`               | Display system info with ASCII art          |
 | `jsh`       | `bash`     | `jsh`                  | A simple, minimal, and interactive shell    |
+| `clr`       | `clear`    | `clr`                  | Clears the terminal screen                  |
 ---
 
 ## Usage Examples

--- a/clr.c
+++ b/clr.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    /* 
+        Check if the user passed any arguments. 
+        'clr' doesn't take arguments, so if there are any, 
+        print usage to stderr and exit with an error code.
+    */
+    if (argc != 1) {
+        fprintf(stderr, "Usage: clr\n");
+        return 1;
+    }
+
+    /*
+      ANSI escape sequences used:
+      \033[H   : Moves the cursor to the home position (top left).
+      \033[2J  : Clears the entire screen.
+      \033[3J  : Clears the scrollback buffer (supported in most modern terminals).
+    */
+    printf("\033[H\033[2J\033[3J"); // I serached that lol
+
+    // Flush stdout to ensure the terminal processes the escape sequences immediately
+    fflush(stdout);
+
+    return 0; 
+
+    // Now to try this print in the terminal 'gcc -std=c99 -o clr clr.c', then './clr' and your terminal should be clear
+}


### PR DESCRIPTION
Added the **clr** command to clear the terminal screen using ANSI escape sequences. It is under 20 lines of code, has 0 external dependencies, and usage/error messages are properly sent to stderr as per the CONTRIBUTING.md guidelines. Updated Makefile and README.md accordingly.